### PR TITLE
72 Export Transkript to ChatGPT.com

### DIFF
--- a/42Summaries/Views/ExportOptionsView.swift
+++ b/42Summaries/Views/ExportOptionsView.swift
@@ -1,19 +1,46 @@
-// ExportOptionsView.swift
-
 import SwiftUI
 
 struct ExportOptionsView: View {
+    enum ExportSource {
+        case transcription
+        case summary
+    }
+    
     let content: String
     let fileName: String
+    let selectedPrompt: String?
+    let source: ExportSource // New parameter
     @Binding var fontSize: CGFloat
     @Binding var textAlignment: TextAlignment
     @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject private var notificationManager: NotificationManager
+    @State private var showingChatGPTInstructions = false
+    @State private var showingClaudeAIInstructions = false
+    @State private var showingPerplexityInstructions: Bool = false
     
     var body: some View {
         VStack(spacing: 20) {
             Text("Export Options")
                 .font(.title)
                 .fontWeight(.bold)
+            
+            if source == .transcription {
+                Button("Export to ChatGPT") {
+                    showingChatGPTInstructions = true
+                }
+            }
+            
+            if source == .transcription {
+                Button("Export to Claude") {
+                    showingClaudeAIInstructions = true
+                }
+            }
+            
+            if source == .transcription {
+                Button("Export to Perplexity") {
+                    showingPerplexityInstructions = true
+                }
+            }
             
             Button("Export as PDF") {
                 ExportManager.exportAsPDF(content: content, fontSize: fontSize, alignment: textAlignment.toNSTextAlignment(), fileName: fileName)
@@ -30,6 +57,127 @@ struct ExportOptionsView: View {
             }
         }
         .padding()
+        .alert("Export to ChatGPT", isPresented: $showingChatGPTInstructions) {
+            Button("Continue") {
+                exportToChatGPT()
+                presentationMode.wrappedValue.dismiss()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("""
+                 The content has been copied to your clipboard.
+                 After clicking Continue:\n
+                 1. ChatGPT will open in your browser
+                 2. Wait for the page to load
+                 3. Click in the chat input field
+                 4. Press Cmd+V to paste
+                 """)
+        }
+        .alert("Export to Claude", isPresented: $showingClaudeAIInstructions) {
+            Button("Continue") {
+                exportToClaudeAI()
+                presentationMode.wrappedValue.dismiss()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("""
+                The content has been copied to your clipboard.
+                After clicking Continue:\n
+                1. Claude will open in your browser
+                2. Wait for the page to load
+                3. Click in the chat input field
+                4. Press Cmd+V to paste
+                """)
+            }
+        .alert("Export to Perplexity", isPresented: $showingPerplexityInstructions) {
+            Button("Continue") {
+                exportToPPLX()
+                presentationMode.wrappedValue.dismiss() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+                Text("""
+                The content has been copied to your clipboard.
+                After clicking Continue:\n
+                1. Perplexity will open in your browser
+                2. Wait for the page to load
+                3. Click in the chat input field
+                4. Select Writing Focus
+                5. Deactivate Pro Mode
+                6. Press Cmd+V to paste
+                """)
+            }
+        }
+    
+    private func exportToChatGPT() {
+        let providerURL = "https://chat.openai.com"
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        
+        // Format the content with the prompt if available
+        var exportContent = ""
+        if let prompt = selectedPrompt {
+            exportContent += prompt + "\n\n"
+        }
+        exportContent += content
+        
+        pasteboard.setString(exportContent, forType: .string)
+        
+        if let url = URL(string: providerURL) {
+            NSWorkspace.shared.open(url)
+        }
+        
+        notificationManager.showNotification(
+            title: "Content Copied",
+            body: "ChatGPT is opening. Press Cmd+V to paste when ready."
+        )
+    }
+    
+    private func exportToClaudeAI() {
+        let providerURL = "https://claude.ai"
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        
+        // Format the content with the prompt if available
+        var exportContent = ""
+        if let prompt = selectedPrompt {
+            exportContent += prompt + "\n\n"
+        }
+        exportContent += content
+        
+        pasteboard.setString(exportContent, forType: .string)
+        
+        if let url = URL(string: providerURL) {
+            NSWorkspace.shared.open(url)
+        }
+        
+        notificationManager.showNotification(
+            title: "Content Copied",
+            body: "Claude is opening. Press Cmd+V to paste when ready."
+        )
+    }
+    
+    private func exportToPPLX() {
+        let providerURL = "https://www.perplexity.ai/search?mode=writing"
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        
+        // Format the content with the prompt if available
+        var exportContent = ""
+        if let prompt = selectedPrompt {
+            exportContent += prompt + "\n\n"
+        }
+        exportContent += content
+        
+        pasteboard.setString(exportContent, forType: .string)
+        
+        if let url = URL(string: providerURL) {
+            NSWorkspace.shared.open(url)
+        }
+        
+        notificationManager.showNotification(
+            title: "Content Copied",
+            body: "Perplexity is opening. Press Cmd+V to paste when ready."
+        )
     }
 }
 

--- a/42Summaries/Views/SummaryView.swift
+++ b/42Summaries/Views/SummaryView.swift
@@ -19,6 +19,19 @@ class SummaryViewModel: ObservableObject {
         self.appState = appState
     }
     
+    func getSelectedPrompt() -> String? {
+        if let storedPrompts = UserDefaults.standard.data(forKey: "prompts") {
+            do {
+                let prompts = try JSONDecoder().decode([Prompt].self, from: storedPrompts)
+                let selectedPromptId = UserDefaults.standard.string(forKey: "selectedPromptId") ?? ""
+                return prompts.first(where: { $0.id.uuidString == selectedPromptId })?.content
+            } catch {
+                print("Error decoding prompts: \(error)")
+            }
+        }
+        return nil
+    }
+    
     func generateSummary(from transcription: String) {
         isGeneratingSummary = true
         errorMessage = nil
@@ -233,6 +246,8 @@ struct SummaryView: View {
             ExportOptionsView(
                 content: appState.summary,
                 fileName: "Summary",
+                selectedPrompt: viewModel.getSelectedPrompt(),
+                source: .summary,
                 fontSize: $viewModel.fontSize,
                 textAlignment: $viewModel.textAlignment
             )


### PR DESCRIPTION
Added new export options to the ExportOptionsView, SummaryView, and TranscriptionView. Users can now choose to export content directly to ChatGPT, ClaudeAI, or Perplexity. The selected prompt is also included in the exported content if available. Additionally, notifications have been implemented to guide users through the export process and confirm successful exports.
